### PR TITLE
feat: LinkedIn visitor CTA

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -134,6 +134,10 @@
         overrides['newsletter-variant'] = true;
       }
 
+      if (params.get('utm_source') === 'linkedin' || document.referrer.indexOf('linkedin.com') !== -1) {
+        overrides['linkedin-visitor-cta'] = true;
+      }
+
       if (Object.keys(overrides).length > 0) {
         posthog.featureFlags.override(overrides);
       }

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,10 @@
 layout: default
 ---
 
+<div id="linkedin-cta" style="display:none" class="linkedin-cta">
+  <p id="linkedin-cta-text"></p>
+</div>
+
 <div class="home">
 
     <section class="bio">
@@ -23,3 +27,27 @@ layout: default
     </section>
 
 </div>
+
+<script>
+  posthog.onFeatureFlags(function () {
+    if (posthog.isFeatureEnabled('linkedin-visitor-cta')) {
+      var lang = document.documentElement.lang || 'it';
+      var ctaEl = document.getElementById('linkedin-cta');
+      var ctaText = document.getElementById('linkedin-cta-text');
+
+      if (lang === 'en') {
+        ctaText.innerHTML = 'Want to get to know me and see if there\'s a fit with your project? <a href="https://cal.com/matpet">Let\'s have a chat \u2192</a>';
+      } else {
+        ctaText.innerHTML = 'Desideri conoscermi e capire se c\u2019\u00e8 un fit con il tuo progetto? <a href="https://cal.com/matpet">Facciamoci una chiacchierata \u2192</a>';
+      }
+
+      ctaEl.style.display = 'block';
+
+      // Hide the "always open for a chat" paragraph (last <p> in .bio)
+      var bioParagraphs = document.querySelectorAll('.bio p');
+      if (bioParagraphs.length) {
+        bioParagraphs[bioParagraphs.length - 1].style.display = 'none';
+      }
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- Detects LinkedIn traffic via `utm_source=linkedin` or `document.referrer`
- Overrides the `linkedin-visitor-cta` PostHog feature flag for those visitors
- Shows a bilingual CTA (IT/EN) linking to cal.com/matpet and hides the generic "open for a chat" paragraph

## Test plan
- [ ] Visit site with `?utm_source=linkedin` — CTA should appear
- [ ] Visit site from linkedin.com referrer — CTA should appear
- [ ] Verify correct language shown based on page lang attribute
- [ ] Verify "always open for a chat" paragraph is hidden when CTA is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)